### PR TITLE
add capture tirgger type that stops token movement on the target token.

### DIFF
--- a/module.json
+++ b/module.json
@@ -2,13 +2,13 @@
   "name": "trigger-happy",
   "title": "Trigger Happy",
   "description": "Automate everything in your world by creating triggers for your players to spring traps or anything you can think of!",
-  "version": "0.4Z",
+  "version": "0.3",
   "author": "KaKaRoTo, tposney",
   "scripts": ["trigger.js"],
   "styles": [],
   "packs": [],
   "url": "https://github.com/kakaroto/fvtt-module-trigger-happy",
   "manifest": "https://raw.githubusercontent.com/kakaroto/fvtt-module-trigger-happy/master/module.json",
-  "download": "https://github.com/kakaroto/fvtt-module-trigger-happy/archive/v0.4.zip",
+  "download": "https://github.com/kakaroto/fvtt-module-trigger-happy/archive/v0.3.zip",
   "minimumCoreVersion": "0.5.3"
 }

--- a/module.json
+++ b/module.json
@@ -2,13 +2,13 @@
   "name": "trigger-happy",
   "title": "Trigger Happy",
   "description": "Automate everything in your world by creating triggers for your players to spring traps or anything you can think of!",
-  "version": "0.3",
+  "version": "0.4Z",
   "author": "KaKaRoTo, tposney",
   "scripts": ["trigger.js"],
   "styles": [],
   "packs": [],
   "url": "https://github.com/kakaroto/fvtt-module-trigger-happy",
   "manifest": "https://raw.githubusercontent.com/kakaroto/fvtt-module-trigger-happy/master/module.json",
-  "download": "https://github.com/kakaroto/fvtt-module-trigger-happy/archive/v0.3.zip",
+  "download": "https://github.com/kakaroto/fvtt-module-trigger-happy/archive/v0.4.zip",
   "minimumCoreVersion": "0.5.3"
 }

--- a/trigger.js
+++ b/trigger.js
@@ -16,8 +16,6 @@ class TriggerHappy {
         Hooks.on('updateJournalEntry', this._parseJournals.bind(this));
         Hooks.on('deleteJournalEntry', this._parseJournals.bind(this));
         Hooks.on("preUpdateToken", this._onPreUpdateToken.bind(this));
-        //Hooks.on("preUpdateToken", this._finishTokenTriggers.bind(this));
-
 
         this.triggers = [];
     }
@@ -219,12 +217,12 @@ class TriggerHappy {
         let targets = this._getTokensFromTriggers(canvas.tokens.placeables, this.triggers, 'capture');
         if (!targets) return true;
 
-        let finalX = update.x || token.x;
-        let finalY = update.y || token.y;
+        const finalX = update.x || token.x;
+        const finalY = update.y || token.y;
         // need to calculate this by hand since token is just token data
-        let tw = token.width * canvas.scene.data.grid / 2;
-        let th = token.height * canvas.scene.data.grid / 2;
-        let motion = new Ray({x: token.x + tw, y: token.y + th}, {x: finalX + tw, y: finalY + th});
+        const tw = token.width * canvas.scene.data.grid / 2;
+        const th = token.height * canvas.scene.data.grid / 2;
+        const motion = new Ray({x: token.x + tw, y: token.y + th}, {x: finalX + tw, y: finalY + th});
 
         // don't trigger on tokens that are already captured
         targets = targets.filter(target => token.x + tw !== target.center.x || token.y + th !== target.center.y)
@@ -232,7 +230,7 @@ class TriggerHappy {
         // sort list by distance from start token position
         targets.sort((a , b) => targets.sort((a, b) => Math.hypot(token.x - b.x, token.y - b.y) - Math.hypot(token.x - a.x, token.y - a.y)))
         
-        targets.forEach(target => {
+        for (let target of targets) {
             // test motion vs token diagonals
             if (motion.intersectSegment([target.x, target.y, target.x + target.w, target.y + target.h])
             || motion.intersectSegment([target.x, target.y + target.h, target.x + target.w, target.y])) {
@@ -240,7 +238,7 @@ class TriggerHappy {
                 update.y = target.center.y - th;
                 return true;
             }
-        })
+        }
         return true;
     }
     _onPreUpdateToken(scene, id, update) {

--- a/trigger.js
+++ b/trigger.js
@@ -143,7 +143,6 @@ class TriggerHappy {
     }
     _getTokensAt(tokens, position) {
         return tokens.filter(target => {
-            console.log("target ", target.name,  target.data.x, target.data.y, target.w, target.h, target.data.width, target.data.height)
             return (target.data.x <= position.x) && (target.data.x + target.w >= position.x)
                 && (target.data.y <= position.y) && (target.data.y + target.h >= position.y);
         });


### PR DESCRIPTION
For some reason directly calling the original preUpdateHook causes some double calling problems. I am sure there is a simple fix, but decided that since this just works it was not worth the effort. I'm sure you'll find the reason there was a problem.

@Trigger[capture] means the tokens movement will get stopped at the target token.

There is also an anomaly when using traced paths, the motion completes and then the token is sucked to the target token - I'm guessing the token.preUpdate fires later in the chain for that. Also decided it was an edge case not worth pursuing. Besides it will give Atropos something to tinker with.
So the new trigger happy looks like
@Token[Target1a] @Trigger[capture[ @Trigger[move] @ChatMessage[/TeleportToToken Target1b -1 2]   